### PR TITLE
Add in-theaters endpoint for Finnkino movies

### DIFF
--- a/docs/IN_THEATERS_ENDPOINT.md
+++ b/docs/IN_THEATERS_ENDPOINT.md
@@ -1,0 +1,208 @@
+# In Theaters Endpoint Documentation
+
+## Overview
+Endpoint that fetches movies currently in theaters (movies with Finnkino ID in database).
+
+## Endpoint
+
+### GET `/api/v1/tmdb/in-theaters`
+
+Get movies that are currently in theaters (have Finnkino ID).
+
+## Query Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `limit` | integer | No | 10 | Maximum number of movies to return (1-100) |
+| `offset` | integer | No | 0 | Number of movies to skip (for pagination) |
+
+## Response Format
+
+```json
+{
+  "success": true,
+  "results": [
+    {
+      "id": 1100988,
+      "title": "Weapons",
+      "originalTitle": "Weapons",
+      "releaseDate": "2025-01-01",
+      "releaseYear": 2025,
+      "posterPath": "https://image.tmdb.org/t/p/w500/bbSHSJuO5XjrIKMh6QXXLTg3Yzr.jpg",
+      "f_id": 305017,
+      "fromDatabase": true,
+      "createdAt": "2025-10-04T12:00:00.000Z"
+    }
+  ],
+  "total": 25,
+  "limit": 10,
+  "offset": 0,
+  "hasMore": true
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | boolean | Whether the request was successful |
+| `results` | array | Array of movie objects |
+| `results[].id` | integer | TMDB movie ID |
+| `results[].title` | string | Movie title |
+| `results[].originalTitle` | string | Original movie title |
+| `results[].releaseDate` | string | Release date (YYYY-MM-DD) |
+| `results[].releaseYear` | integer | Release year |
+| `results[].posterPath` | string | Full URL to movie poster |
+| `results[].f_id` | integer | Finnkino ID |
+| `results[].fromDatabase` | boolean | Always `true` for this endpoint |
+| `results[].createdAt` | string | When movie was added to database |
+| `total` | integer | Total number of movies with Finnkino ID |
+| `limit` | integer | Limit used in query |
+| `offset` | integer | Offset used in query |
+| `hasMore` | boolean | Whether there are more results available |
+
+## Examples
+
+### Get first 10 movies in theaters
+```bash
+GET /api/v1/tmdb/in-theaters
+```
+
+### Get specific page (carousel)
+```bash
+GET /api/v1/tmdb/in-theaters?limit=10&offset=0
+```
+
+### Get next page
+```bash
+GET /api/v1/tmdb/in-theaters?limit=10&offset=10
+```
+
+### Get all movies (up to 100)
+```bash
+GET /api/v1/tmdb/in-theaters?limit=100&offset=0
+```
+
+## Error Responses
+
+### Invalid limit
+```json
+{
+  "success": false,
+  "error": "Limit must be between 1 and 100"
+}
+```
+
+### Invalid offset
+```json
+{
+  "success": false,
+  "error": "Offset must be 0 or greater"
+}
+```
+
+## Use Cases
+
+### 1. Homepage Carousel (10 movies)
+```javascript
+fetch('/api/v1/tmdb/in-theaters?limit=10')
+  .then(res => res.json())
+  .then(data => {
+    // data.results contains 10 most recent theater movies
+    renderCarousel(data.results);
+  });
+```
+
+### 2. Full Theater Listing with Pagination
+```javascript
+async function loadTheaterMovies(page = 1) {
+  const limit = 20;
+  const offset = (page - 1) * limit;
+  
+  const response = await fetch(`/api/v1/tmdb/in-theaters?limit=${limit}&offset=${offset}`);
+  const data = await response.json();
+  
+  return {
+    movies: data.results,
+    totalPages: Math.ceil(data.total / limit),
+    currentPage: page,
+    hasMore: data.hasMore
+  };
+}
+```
+
+### 3. Check if any movies are in theaters
+```javascript
+fetch('/api/v1/tmdb/in-theaters?limit=1')
+  .then(res => res.json())
+  .then(data => {
+    if (data.total > 0) {
+      console.log(`${data.total} movies currently in theaters`);
+    } else {
+      console.log('No movies in theaters');
+    }
+  });
+```
+
+## Architecture
+
+The endpoint follows MVC pattern:
+
+```
+Controller (TMDBController.js)
+    ↓
+Service (TMDBService.js)
+    ↓
+Model (Movie.js)
+    ↓
+Database (PostgreSQL)
+```
+
+### Database Query
+
+The `Movie.findWithFinnkinoId()` method queries the `movies` table:
+
+```sql
+SELECT 
+  id,
+  original_title,
+  release_year,
+  tmdb_id,
+  poster_url,
+  f_id,
+  created_at
+FROM movies 
+WHERE f_id IS NOT NULL
+ORDER BY created_at DESC
+LIMIT $1 OFFSET $2
+```
+
+## Notes
+
+- **Default Limit**: 10 movies (perfect for carousel)
+- **Maximum Limit**: 100 movies (to prevent performance issues)
+- **Ordering**: Most recently added movies first (`created_at DESC`)
+- **Filtering**: Only movies with `f_id IS NOT NULL` (Finnkino movies)
+- **Poster URLs**: Full URLs ready to use (no need to construct)
+- **Performance**: Uses database index on `f_id` for fast queries
+
+## Related Endpoints
+
+- **GET `/api/v1/tmdb/title-year`** - Search specific movie by title and year
+- **GET `/api/v1/tmdb/discover`** - Discover movies with filters
+- **GET `/api/v1/tmdb/:id`** - Get detailed movie information
+
+## Integration with Finnkino
+
+When frontend calls Finnkino API and finds a movie:
+1. Frontend gets `f_id` from Finnkino API
+2. Frontend calls `/api/v1/tmdb/title-year?f_id={f_id}` to save movie
+3. Movie appears in `/api/v1/tmdb/in-theaters` response
+4. Movie is cached for future requests
+
+## Performance Considerations
+
+- Uses database indexes for fast queries
+- Pagination prevents loading all movies at once
+- Total count is calculated separately for efficiency
+- Results are ordered by `created_at` (indexed field)

--- a/docs/IN_THEATERS_IMPLEMENTATION.md
+++ b/docs/IN_THEATERS_IMPLEMENTATION.md
@@ -1,0 +1,210 @@
+# In Theaters Endpoint - Implementation Summary
+
+## ✅ Toteutettu
+
+### 1. **Model Layer** (Movie.js)
+Lisätty uusi metodi:
+```javascript
+Movie.findWithFinnkinoId({ limit, offset })
+```
+
+**Mitä tekee:**
+- Hakee kaikki elokuvat joilla `f_id IS NOT NULL`
+- Palauttaa elokuvat, kokonaismäärän ja pagination tiedot
+- Järjestää tulokset `created_at DESC` (uusimmat ensin)
+
+**Sijainti:** `src/models/Movie.js`
+
+### 2. **Service Layer** (TMDBService.js)
+Lisätty uusi metodi:
+```javascript
+TMDBService.getMoviesWithFinnkinoId({ limit, offset })
+```
+
+**Mitä tekee:**
+- Kutsuu `Movie.findWithFinnkinoId()` metodia
+- Formatoi tietokannan datan vastaamaan TMDB API:n muotoa
+- Lisää `fromDatabase: true` kentän
+
+**Sijainti:** `src/services/TMDBService.js`
+
+### 3. **Controller Layer** (TMDBController.js)
+Lisätty uusi controller funktio:
+```javascript
+export const getMoviesInTheaters(req, res)
+```
+
+**Mitä tekee:**
+- Validoi query parametrit (limit, offset)
+- Kutsuu `TMDBService.getMoviesWithFinnkinoId()`
+- Palauttaa JSON vastauksen
+
+**Sijainti:** `src/controllers/TMDBController.js`
+
+### 4. **Routes** (tmdbRoutes.js)
+Lisätty uusi route:
+```javascript
+router.get('/in-theaters', getMoviesInTheaters);
+```
+
+**Endpoint:** `GET /api/v1/tmdb/in-theaters`
+
+**Sijainti:** `src/routes/tmdbRoutes.js`
+
+## 📊 Arkkitehtuuri
+
+```
+Request: GET /api/v1/tmdb/in-theaters?limit=10&offset=0
+    ↓
+Router (tmdbRoutes.js)
+    ↓
+Controller (TMDBController.getMoviesInTheaters)
+    - Validoi parametrit
+    - Käsittelee virheet
+    ↓
+Service (TMDBService.getMoviesWithFinnkinoId)
+    - Liiketoimintalogiikka
+    - Datan formatointi
+    ↓
+Model (Movie.findWithFinnkinoId)
+    - Tietokantakutsut
+    - SQL queryt
+    ↓
+Database (PostgreSQL)
+    - movies table
+    - WHERE f_id IS NOT NULL
+    ↓
+Response: JSON { success, results, total, limit, offset, hasMore }
+```
+
+## 🎯 Default Behavior
+
+- **Default limit:** 10 (täydellinen karuselleille)
+- **Default offset:** 0
+- **Max limit:** 100
+- **Järjestys:** Uusimmat ensin (created_at DESC)
+- **Filtteri:** Vain elokuvat joilla f_id olemassa
+
+## 📝 Query Parameters
+
+| Parameter | Type | Default | Min | Max | Required |
+|-----------|------|---------|-----|-----|----------|
+| limit | integer | 10 | 1 | 100 | No |
+| offset | integer | 0 | 0 | ∞ | No |
+
+## 📤 Response Format
+
+```json
+{
+  "success": true,
+  "results": [
+    {
+      "id": 1100988,
+      "title": "Weapons",
+      "originalTitle": "Weapons",
+      "releaseDate": "2025-01-01",
+      "releaseYear": 2025,
+      "posterPath": "https://image.tmdb.org/t/p/w500/...",
+      "f_id": 305017,
+      "fromDatabase": true,
+      "createdAt": "2025-10-04T12:00:00.000Z"
+    }
+  ],
+  "total": 25,
+  "limit": 10,
+  "offset": 0,
+  "hasMore": true
+}
+```
+
+## 🧪 Testing
+
+Testiskripti: `test-in-theaters.ps1`
+
+Testaa:
+1. Default haku (10 elokuvaa)
+2. Custom limit (5 elokuvaa)
+3. Pagination (offset 10)
+4. Virheellinen limit (>100)
+5. Virheellinen offset (<0)
+6. Maksimi haku (100 elokuvaa)
+
+## 📚 Documentation
+
+- **API Docs:** `docs/IN_THEATERS_ENDPOINT.md`
+- **Test Script:** `test-in-theaters.ps1`
+- **This Summary:** `docs/IN_THEATERS_IMPLEMENTATION.md`
+
+## 🔗 Related Features
+
+### Finnkino Integration
+Kun frontend hakee elokuvan Finnkino API:sta:
+1. Frontend saa `f_id` (Finnkino ID)
+2. Frontend kutsuu `/api/v1/tmdb/title-year?f_id=305017`
+3. Backend tallentaa elokuvan `f_id`:n kanssa
+4. Elokuva näkyy `/api/v1/tmdb/in-theaters` vastauksessa
+
+### Database Schema
+```sql
+CREATE TABLE movies (
+  id VARCHAR(255) PRIMARY KEY,
+  original_title VARCHAR(255) NOT NULL,
+  release_year INTEGER,
+  tmdb_id INTEGER,
+  poster_url TEXT,
+  f_id INTEGER UNIQUE,  -- Finnkino ID
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_movies_f_id ON movies(f_id);
+```
+
+## 🚀 Use Cases
+
+### 1. Homepage Carousel
+```javascript
+fetch('/api/v1/tmdb/in-theaters?limit=10')
+  .then(res => res.json())
+  .then(data => renderCarousel(data.results));
+```
+
+### 2. Mobile Carousel (smaller)
+```javascript
+fetch('/api/v1/tmdb/in-theaters?limit=5')
+```
+
+### 3. Full Theater Listing
+```javascript
+fetch('/api/v1/tmdb/in-theaters?limit=20&offset=0')
+```
+
+### 4. Pagination
+```javascript
+const page = 2;
+const limit = 20;
+const offset = (page - 1) * limit;
+fetch(`/api/v1/tmdb/in-theaters?limit=${limit}&offset=${offset}`)
+```
+
+## ⚡ Performance
+
+- **Database Index:** `f_id` column indexed
+- **Optimized Query:** Only selects needed columns
+- **Pagination:** Prevents loading all movies at once
+- **Separate Count:** Total count calculated efficiently
+
+## 🔒 Security
+
+- **Input Validation:** limit (1-100), offset (≥0)
+- **SQL Injection:** Prevented by parameterized queries
+- **Error Handling:** Generic error messages to client
+- **No Authentication:** Public endpoint (read-only)
+
+## 📈 Future Enhancements
+
+Mahdollisia parannuksia:
+- Cache results for 5-10 minutes
+- Add sorting options (by title, year, etc.)
+- Filter by release year
+- Search by title within theater movies
+- Add theater location info from Finnkino API

--- a/src/controllers/TMDBController.js
+++ b/src/controllers/TMDBController.js
@@ -133,4 +133,43 @@ export const getMoviesByTitleAndYear = async (req, res) => {
   }
 };
 
+export const getMoviesInTheaters = async (req, res) => {
+  try {
+    const { limit = 10, offset = 0 } = req.query;
+
+    // Validate limit
+    const limitNum = parseInt(limit);
+    if (isNaN(limitNum) || limitNum < 1 || limitNum > 100) {
+      return res.status(400).json({
+        success: false,
+        error: 'Limit must be between 1 and 100'
+      });
+    }
+
+    // Validate offset
+    const offsetNum = parseInt(offset);
+    if (isNaN(offsetNum) || offsetNum < 0) {
+      return res.status(400).json({
+        success: false,
+        error: 'Offset must be 0 or greater'
+      });
+    }
+
+    const results = await TMDBService.getMoviesWithFinnkinoId({
+      limit: limitNum,
+      offset: offsetNum
+    });
+
+    res.json({
+      success: true,
+      ...results
+    });
+  } catch (error) {
+    console.error('Error getting movies in theaters:', error);
+    res.status(500).json({
+      success: false,
+      error: error.message
+    });
+  }
+};
 

--- a/src/models/Movie.js
+++ b/src/models/Movie.js
@@ -193,6 +193,47 @@ class Movie {
     }
   }
 
+  // Find all movies with Finnkino ID (movies currently in theaters)
+  static async findWithFinnkinoId({ limit = 100, offset = 0 } = {}) {
+    try {
+      // Get movies with f_id
+      const result = await query(
+        `SELECT 
+          id,
+          original_title,
+          release_year,
+          tmdb_id,
+          poster_url,
+          f_id,
+          created_at
+        FROM movies 
+        WHERE f_id IS NOT NULL
+        ORDER BY created_at DESC
+        LIMIT $1 OFFSET $2`,
+        [limit, offset]
+      );
+
+      // Get total count
+      const countResult = await query(
+        `SELECT COUNT(*) as total
+        FROM movies 
+        WHERE f_id IS NOT NULL`
+      );
+
+      const total = parseInt(countResult.rows[0].total);
+
+      return {
+        movies: result.rows,
+        total,
+        limit,
+        offset,
+        hasMore: offset + limit < total
+      };
+    } catch (error) {
+      throw new Error(`Error finding movies with Finnkino ID: ${error.message}`);
+    }
+  }
+
   // Create or update movie from TMDB data
   static async createFromTmdb(tmdbData) {
     try {

--- a/src/routes/tmdbRoutes.js
+++ b/src/routes/tmdbRoutes.js
@@ -3,7 +3,8 @@ import {
   searchMovies, 
   getMovieDetails, 
   getMoviesByTitleAndYear,
-  discoverMovies
+  discoverMovies,
+  getMoviesInTheaters
 } from '../controllers/TMDBController.js';
 
 import { getLocalGenres } from '../controllers/GenresController.js';
@@ -15,6 +16,9 @@ router.get('/search', searchMovies);
 
 // Get Genres from local database
 router.get('/genres', getLocalGenres);
+
+// Get movies currently in theaters (with Finnkino ID)
+router.get('/in-theaters', getMoviesInTheaters);
 
 // Get movies by title & year
 router.get('/title-year', getMoviesByTitleAndYear);

--- a/test-in-theaters.ps1
+++ b/test-in-theaters.ps1
@@ -1,0 +1,148 @@
+# Test In Theaters Endpoint
+# Tests the /api/v1/tmdb/in-theaters endpoint
+
+$API_URL = "http://localhost:3000/api/v1"
+
+Write-Host "=====================================" -ForegroundColor Cyan
+Write-Host "In Theaters Endpoint Test" -ForegroundColor Cyan
+Write-Host "=====================================" -ForegroundColor Cyan
+Write-Host ""
+
+# Test 1: Get default (first 10 movies)
+Write-Host "📽️  Test 1: Get first 10 movies (default carousel)" -ForegroundColor Yellow
+Write-Host "GET $API_URL/tmdb/in-theaters"
+try {
+    $response = Invoke-RestMethod -Uri "$API_URL/tmdb/in-theaters" -Method Get
+    
+    Write-Host "✅ Success!" -ForegroundColor Green
+    Write-Host "   Total movies in theaters: $($response.total)" -ForegroundColor White
+    Write-Host "   Movies returned: $($response.results.Count)" -ForegroundColor White
+    Write-Host "   Limit: $($response.limit)" -ForegroundColor White
+    Write-Host "   Offset: $($response.offset)" -ForegroundColor White
+    Write-Host "   Has more: $($response.hasMore)" -ForegroundColor White
+    
+    if ($response.results.Count -gt 0) {
+        Write-Host ""
+        Write-Host "   First movie:" -ForegroundColor Cyan
+        $firstMovie = $response.results[0]
+        Write-Host "   - Title: $($firstMovie.title)" -ForegroundColor White
+        Write-Host "   - Original Title: $($firstMovie.originalTitle)" -ForegroundColor White
+        Write-Host "   - Year: $($firstMovie.releaseYear)" -ForegroundColor White
+        Write-Host "   - TMDB ID: $($firstMovie.id)" -ForegroundColor White
+        Write-Host "   - Finnkino ID: $($firstMovie.f_id)" -ForegroundColor White
+        Write-Host "   - Poster: $($firstMovie.posterPath)" -ForegroundColor White
+        Write-Host "   - From Database: $($firstMovie.fromDatabase)" -ForegroundColor White
+    }
+    Write-Host ""
+} catch {
+    Write-Host "❌ Error: $_" -ForegroundColor Red
+    Write-Host ""
+}
+
+# Test 2: Get specific limit (5 movies for smaller carousel)
+Write-Host "📽️  Test 2: Get 5 movies (smaller carousel)" -ForegroundColor Yellow
+Write-Host "GET $API_URL/tmdb/in-theaters?limit=5"
+try {
+    $response = Invoke-RestMethod -Uri "$API_URL/tmdb/in-theaters?limit=5" -Method Get
+    
+    Write-Host "✅ Success!" -ForegroundColor Green
+    Write-Host "   Movies returned: $($response.results.Count)" -ForegroundColor White
+    Write-Host "   Limit: $($response.limit)" -ForegroundColor White
+    Write-Host ""
+} catch {
+    Write-Host "❌ Error: $_" -ForegroundColor Red
+    Write-Host ""
+}
+
+# Test 3: Pagination - Get second page
+Write-Host "📽️  Test 3: Get second page (offset 10)" -ForegroundColor Yellow
+Write-Host "GET $API_URL/tmdb/in-theaters?limit=10&offset=10"
+try {
+    $response = Invoke-RestMethod -Uri "$API_URL/tmdb/in-theaters?limit=10&offset=10" -Method Get
+    
+    Write-Host "✅ Success!" -ForegroundColor Green
+    Write-Host "   Movies returned: $($response.results.Count)" -ForegroundColor White
+    Write-Host "   Offset: $($response.offset)" -ForegroundColor White
+    Write-Host "   Has more: $($response.hasMore)" -ForegroundColor White
+    Write-Host ""
+} catch {
+    Write-Host "❌ Error: $_" -ForegroundColor Red
+    Write-Host ""
+}
+
+# Test 4: Invalid limit (should fail)
+Write-Host "❌ Test 4: Invalid limit (should fail)" -ForegroundColor Yellow
+Write-Host "GET $API_URL/tmdb/in-theaters?limit=150"
+try {
+    $response = Invoke-RestMethod -Uri "$API_URL/tmdb/in-theaters?limit=150" -Method Get -ErrorAction Stop
+    Write-Host "❌ Test failed - should have returned error!" -ForegroundColor Red
+    Write-Host ""
+} catch {
+    $errorResponse = $_.ErrorDetails.Message | ConvertFrom-Json
+    if ($errorResponse.error -like "*between 1 and 100*") {
+        Write-Host "✅ Correctly rejected invalid limit!" -ForegroundColor Green
+        Write-Host "   Error: $($errorResponse.error)" -ForegroundColor White
+    } else {
+        Write-Host "❌ Unexpected error: $($errorResponse.error)" -ForegroundColor Red
+    }
+    Write-Host ""
+}
+
+# Test 5: Invalid offset (should fail)
+Write-Host "❌ Test 5: Invalid offset (should fail)" -ForegroundColor Yellow
+Write-Host "GET $API_URL/tmdb/in-theaters?offset=-1"
+try {
+    $response = Invoke-RestMethod -Uri "$API_URL/tmdb/in-theaters?offset=-1" -Method Get -ErrorAction Stop
+    Write-Host "❌ Test failed - should have returned error!" -ForegroundColor Red
+    Write-Host ""
+} catch {
+    $errorResponse = $_.ErrorDetails.Message | ConvertFrom-Json
+    if ($errorResponse.error -like "*0 or greater*") {
+        Write-Host "✅ Correctly rejected invalid offset!" -ForegroundColor Green
+        Write-Host "   Error: $($errorResponse.error)" -ForegroundColor White
+    } else {
+        Write-Host "❌ Unexpected error: $($errorResponse.error)" -ForegroundColor Red
+    }
+    Write-Host ""
+}
+
+# Test 6: Get all movies (max limit)
+Write-Host "📽️  Test 6: Get maximum movies (limit=100)" -ForegroundColor Yellow
+Write-Host "GET $API_URL/tmdb/in-theaters?limit=100"
+try {
+    $response = Invoke-RestMethod -Uri "$API_URL/tmdb/in-theaters?limit=100" -Method Get
+    
+    Write-Host "✅ Success!" -ForegroundColor Green
+    Write-Host "   Total in database: $($response.total)" -ForegroundColor White
+    Write-Host "   Movies returned: $($response.results.Count)" -ForegroundColor White
+    Write-Host "   Has more: $($response.hasMore)" -ForegroundColor White
+    Write-Host ""
+} catch {
+    Write-Host "❌ Error: $_" -ForegroundColor Red
+    Write-Host ""
+}
+
+# Summary
+Write-Host "=====================================" -ForegroundColor Cyan
+Write-Host "Test Summary" -ForegroundColor Cyan
+Write-Host "=====================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Endpoint: GET /api/v1/tmdb/in-theaters" -ForegroundColor White
+Write-Host ""
+Write-Host "Query Parameters:" -ForegroundColor White
+Write-Host "  - limit: 1-100 (default: 10)" -ForegroundColor White
+Write-Host "  - offset: 0+ (default: 0)" -ForegroundColor White
+Write-Host ""
+Write-Host "Response Fields:" -ForegroundColor White
+Write-Host "  - results: Array of movies with f_id" -ForegroundColor White
+Write-Host "  - total: Total count in database" -ForegroundColor White
+Write-Host "  - limit: Limit used" -ForegroundColor White
+Write-Host "  - offset: Offset used" -ForegroundColor White
+Write-Host "  - hasMore: Boolean for pagination" -ForegroundColor White
+Write-Host ""
+Write-Host "Use Cases:" -ForegroundColor White
+Write-Host "  - Homepage carousel: ?limit=10" -ForegroundColor White
+Write-Host "  - Mobile carousel: ?limit=5" -ForegroundColor White
+Write-Host "  - Full listing: ?limit=20&offset=0" -ForegroundColor White
+Write-Host "  - Next page: ?limit=20&offset=20" -ForegroundColor White
+Write-Host ""


### PR DESCRIPTION
Implements GET /api/v1/tmdb/in-theaters to fetch movies with Finnkino ID from the database, including pagination and input validation. Adds supporting model, service, controller, route, documentation, and a PowerShell test script.